### PR TITLE
shardcache client: calloc() our auth secret if we have one

### DIFF
--- a/src/shardcache_client.c
+++ b/src/shardcache_client.c
@@ -76,8 +76,10 @@ shardcache_client_t *shardcache_client_create(shardcache_node_t *nodes, int num_
 
     c->chash = chash_create((const char **)shard_names, shard_lens, c->num_shards, 200);
 
-    if (auth && strlen(auth))
+    if (auth && strlen(auth)) {
+        c->auth = calloc(1, 16);
         strncpy((char *)c->auth, auth, 16);
+    }
 
     return c;
 }


### PR DESCRIPTION
This is a null pointer deference since c->auth would still be 0 from the calloc() at the top.
