### PR TITLE
Deletion of unnecessary checks before some function calls

### DIFF
--- a/src/shardcache_client.c
+++ b/src/shardcache_client.c
@@ -1219,8 +1219,7 @@ async_job_destroy(async_job_t *job)
             free(job->arg.single.key);
             if (job->arg.single.fd >= 0)
                 close(job->arg.single.fd);
-            if (job->arg.single.wrk)
-                free(job->arg.single.wrk);
+            free(job->arg.single.wrk);
             break;
         case JOB_CMD_GET_MULTI:
             if (job->arg.multi.pools)

--- a/src/shardcache_client.c
+++ b/src/shardcache_client.c
@@ -1222,8 +1222,7 @@ async_job_destroy(async_job_t *job)
             free(job->arg.single.wrk);
             break;
         case JOB_CMD_GET_MULTI:
-            if (job->arg.multi.pools)
-                list_destroy(job->arg.multi.pools);
+            list_destroy(job->arg.multi.pools);
             if (job->arg.multi.contexts) {
                 shc_multi_ctx_t *ctx = NULL;
                 while ((ctx = list_shift_value(job->arg.multi.contexts)))

--- a/test/shardcache_test.c
+++ b/test/shardcache_test.c
@@ -154,8 +154,7 @@ int main(int argc, char **argv)
             ut_failure("%s != %s", vv, v);
             failed = 1;
         }
-        if (vv)
-            free(vv);
+        free(vv);
         int count = i - 100;
         if (count%10 == 0)
             ut_progress(count);

--- a/utils/shardcachec.c
+++ b/utils/shardcachec.c
@@ -221,8 +221,7 @@ int main (int argc, char **argv) {
             shc_multi_item_destroy(items[i]);
             if (out)
                 fclose(out);
-            if (outname)
-                free(outname);
+            free(outname);
         }
     } else if (strcasecmp(cmd, "set") == 0 ||
                strcasecmp(cmd, "add") == 0)
@@ -313,8 +312,7 @@ int main (int argc, char **argv) {
                 printf("%s\n", stats);
             else
                 printf("Error querying node: %s (%s)\n", label, address);
-            if (stats)
-                free(stats);
+            free(stats);
             printf("\n");
         }
         if (found == 0 && selected_node)

--- a/utils/shc_benchmark.c
+++ b/utils/shc_benchmark.c
@@ -547,8 +547,7 @@ main (int argc, char **argv)
                                : counts[i].value;
                 if (!slowest_client || (diff > 0 && slowest_client > diff)) {
                     slowest_client = diff;
-                    if (slowest_label)
-                        free(slowest_label);
+                    free(slowest_label);
                     slowest_label = strdup(counts[i].name);
                 }
 
@@ -595,8 +594,7 @@ main (int argc, char **argv)
                    fastest_client,
                    stuck_clients);
         }
-        if (slowest_label)
-            free(slowest_label);
+        free(slowest_label);
 
         if (stats_file) {
             char line[(10*9) + 10];
@@ -621,8 +619,7 @@ main (int argc, char **argv)
 
 
         num_responses_prev = __sync_add_and_fetch(&num_responses, 0);
-        if (counts)
-            free(counts);
+        free(counts);
     }
 
     for (i = 0; i < num_threads; i++) {


### PR DESCRIPTION
- [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first) is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
- [The function "list_destroy"](https://github.com/xant/libhl/blob/6c07aefcb2e088e3e029ccc8e10d2221a0677c6c/src/linklist.c#L97) performs also input parameter validation. It is therefore not needed that a function caller repeats a corresponding check.
